### PR TITLE
Add right alignment option

### DIFF
--- a/src/config.yaml
+++ b/src/config.yaml
@@ -14,7 +14,7 @@ bars:
     class_name: "yasb-bar"
     alignment:
       position: "top"
-      center: false
+      alignment: "center"
     animation:
       enabled: true
       duration: 1000

--- a/src/core/bar.py
+++ b/src/core/bar.py
@@ -157,16 +157,24 @@ class Bar(QWidget):
             self.app_bar_manager.remove_appbar()
 
     def bar_pos(self, bar_w: int, bar_h: int, screen_w: int, screen_h: int) -> tuple[int, int]:
-        screen_x = self.screen().geometry().x()
-        screen_y = self.screen().geometry().y()
-        x = int(screen_x + (screen_w / 2) - (bar_w / 2)) if self._alignment['center'] else screen_x
+        geom = self.screen().geometry()
+        sx, sy = geom.x(), geom.y()
 
-        if self._alignment['position'] == "bottom":
-            y = int(screen_y + screen_h - bar_h - self._padding['bottom'])
-        else:
-            y = screen_y
-        
+        a = self._alignment['alignment']
+        if a == 'center':
+            x = int(sx + (screen_w - bar_w) / 2)
+        elif a == 'right':
+            x = int(sx + screen_w - bar_w - self._padding['right'])
+        else:  # 'left'
+            x = int(sx + self._padding['left'])
+
+        if self._alignment['position'] == 'bottom':
+            y = int(sy + screen_h - bar_h - self._padding['bottom'])
+        else:  # 'top'
+            y = int(sy + self._padding['top'])
+
         return x, y
+
 
     def position_bar(self, init=False) -> None:
         bar_width = self._dimensions['width']

--- a/src/core/validation/bar.py
+++ b/src/core/validation/bar.py
@@ -2,7 +2,7 @@ BAR_DEFAULTS = {
     'enabled': True,
     'screens': ['*'],
     'class_name': 'yasb-bar',
-    'alignment': {'position': 'top', 'center': False},
+    'alignment': {'position': 'top', 'alignment': 'center'},
     'blur_effect': {'enabled': False, 'dark_mode': False, 'acrylic': False,'round_corners': False,'round_corners_type':'normal','border_color': "System"},
     'animation': {'enabled': True, 'duration': 500},
     'window_flags': {'always_on_top': False, 'windows_app_bar': False, 'hide_on_fullscreen': False, 'auto_hide': False},
@@ -41,9 +41,10 @@ BAR_SCHEMA = {
                     'allowed': ['top', 'bottom'],
                     'default': BAR_DEFAULTS['alignment']['position']
                 },
-                'center': {
-                    'type': 'boolean',
-                    'default': BAR_DEFAULTS['alignment']['center']
+                'alignment': {
+                    'type': 'string',
+                    'allowed': ['left', 'center', 'right'],
+                    'default': BAR_DEFAULTS['alignment']['alignment']
                 }
             },
             'default': BAR_DEFAULTS['alignment']


### PR DESCRIPTION
Added the option for the bar to be right aligned. For anyone else like me who might use the bar at smaller width percentages and wanted the option to left, center, or right align it.

- Updated `BAR_DEFAULTS` to use `alignment: ['left', 'center', 'right']`
- Modified `BAR_SCHEMA` to validate the new `alignment` field
- Refactored `bar_pos()` to calculate x-position for left/center/right
- Added example config snippet to README demonstrating right alignment

Manually tested on Windows 11 Home
Version 23H2 (OS Build 22631.5335)
![Screenshot 2025-05-27 180833](https://github.com/user-attachments/assets/246f0886-1bfe-4c65-8f5d-d223ba7b6137)
